### PR TITLE
Footnote marker feature

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -34,7 +34,8 @@ plugins: [
             //use if you want the Wikipedia style ^ link without an underline beneath it
             footnoteBackRefAnchorStyle: `text-decoration: none;`,
             //use "front" for Wikipedia style ^ links
-            footnoteBackRefInnerTextStartPosition: "front"
+            footnoteBackRefInnerTextStartPosition: "front",
+            useFootnoteMarkerText: false // Defaults to false
           }
         }
       ]
@@ -54,6 +55,8 @@ plugins: [
 `footnoteBackRefAnchorStyle`: As in the example above, if you use `^` you'll want to override the `text-decoration` property (and potentially other ones, like color, if that's your thing) to conform to the Wikipedia style. Can be omitted.
 
 `footnoteBackRefInnerTextStartPosition`: `front` for Wikipedia style, otherwise can be omitted.
+
+`useFootnoteMarkerText`: set to `true` to use footnote's "marker" (how the footnote is introduced between the Markdown brackets) as the footnote "heading" introducing the footnote in the actual footnote section. Markdown by default auto-numbers footnotes, regardless of how they are introduced; if you use a series of footnotes like so [^1] [^second] [^third] the footnotes will auto number to _1, 2, 3_ in the footnote sections. By setting this flag to `true`, the second and third footnotes would be introduced: `second.` and `third.`
 
 ## Considerations
 

--- a/index.js
+++ b/index.js
@@ -62,12 +62,17 @@ module.exports = (
     footnoteBackRefDisplay,
     footnoteBackRefInnerText,
     footnoteBackRefInnerTextStartPosition,
-    footnoteBackRefAnchorStyle
+    footnoteBackRefAnchorStyle,
+    useFootnoteMarkerText = false
   }
 ) => {
   const footnoteBackrefs = [];
 
   visit(markdownAST, `footnoteDefinition`, backrefNode => {
+    if (useFootnoteMarkerText) {
+      backrefNode.id = backrefNode.label;
+    }
+
     footnoteBackrefs.push(backrefNode);
   });
 
@@ -92,7 +97,14 @@ module.exports = (
     `;
 
     const listItem = `
-      <li id="fn-${node.identifier}">
+    ${
+      useFootnoteMarkerText
+        ? `<span style="display: inline">${node.label}.</span>`
+        : ""
+    }
+      <li id="fn-${node.identifier}" ${
+      useFootnoteMarkerText ? `style="display:inline"` : ""
+    }>
         ${
           footnoteBackRefInnerTextStartPosition &&
           footnoteBackRefInnerTextStartPosition === "front"
@@ -100,12 +112,17 @@ module.exports = (
             : pTag + anchorTag
         }
       </li>
+      ${
+        useFootnoteMarkerText && index < footnoteBackrefs.length - 1
+          ? `<br/> <br/>`
+          : ""
+      }
     `;
 
     const openingTag = `
       <div class="footnotes">
         <hr/>
-        <ol>
+        <ol ${useFootnoteMarkerText ? `style="list-style: none;"` : ``}>
     `;
     const closingOl = `</ol></div>`;
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "gatsby-remark-footnotes",
-  "version": "0.0.5",
+  "version": "0.0.6",
   "description": "Customize your gatsby Remark markup footnotes",
   "main": "index.js",
   "author": "James Simone",


### PR DESCRIPTION
Fixes #2 by introducing new flag, `useFootnoteMarkerText`, to opt into using the markdown "marker" for footnotes; by setting this flag to true in the plugin's config, the text used to denote the markdown also shows as the footnote's heading in the actual footnote section